### PR TITLE
Rephrase distributed computing bullet point

### DIFF
--- a/Software_Engineer.md
+++ b/Software_Engineer.md
@@ -17,5 +17,5 @@ The Government Digital Services (GDS) group in GovTech uses technology and data 
 - Experience in API development and web MVC frameworks.
 - Proficiency in JavaScript and a second programming language (preferably Python or Scala).
 - Knowledge of relational and non-relational databases.
-- Knowledge of distributed computing concepts like the Actor Model a plus.
+- Familiarity with distributed systems concepts like MapReduce and the Actor Model a plus.
 - Ability to work comfortably in an Agile and fast-paced environment.


### PR DESCRIPTION
To avoid giving the impression that only people who know the Actor Model 
would have an advantage, re-word the sentence as follows:

* distributed computing -> distributed systems
* add MapReduce to give the impression that we are after 
people who know the wider topic

Fixes #7 